### PR TITLE
fix: details invalid payload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -222,8 +222,8 @@ async function createWindow() {
 
                     info.rpc.user?.setActivity({
                         type: ActivityType.Listening,
-                        details: shortenString(currentTrack.title) + (currentTrack.title.length < 2 ? '⠀⠀' : ''),
-                        state: `${shortenString(trackInfo.author)}`,
+                        details: `${shortenString(currentTrack.title)}${(currentTrack.title.length < 2 ? '⠀⠀' : '')}`,
+                        state: `${shortenString(trackInfo.author)}${(trackInfo.author.length < 2 ? '⠀⠀' : '')}`,
                         largeImageKey: artworkUrl.replace('50x50.', '500x500.'),
                         startTimestamp: Date.now() - elapsedMilliseconds,
                         endTimestamp: Date.now() + (totalMilliseconds - elapsedMilliseconds),

--- a/src/main.ts
+++ b/src/main.ts
@@ -222,7 +222,7 @@ async function createWindow() {
 
                     info.rpc.user?.setActivity({
                         type: ActivityType.Listening,
-                        details: shortenString(currentTrack.title),
+                        details: shortenString(currentTrack.title) + (currentTrack.title.length < 2 ? '⠀⠀' : ''),
                         state: `${shortenString(trackInfo.author)}`,
                         largeImageKey: artworkUrl.replace('50x50.', '500x500.'),
                         startTimestamp: Date.now() - elapsedMilliseconds,


### PR DESCRIPTION
fixes `INVALID_PAYLOAD: child "activity" fails because [child "details" fails because ["details" length must be at least 2 characters long]]` discord rpc error that occurs if track title is less than 2 characters long by adding two U+2800 characters (invisible ones)
allows empty titles to be shown on rpc as well

tracks to reproduce:
[4](https://soundcloud.com/d3197/d-04)
[3](https://soundcloud.com/d3197/d-03)
[empty title](https://soundcloud.com/d1752/helpless)