### PR TITLE
Add back thumbbar widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint -c .eslintrc --ext .ts ./src",
     "copy-header": "cpx \"src/header/**/*\" tsc/header",
-    "dev": "tsc && npm run copy-header && electron ./tsc/main.js",
+    "dev": "tsc && npm run copy-header && electron ./tsc/main.js --dev",
     "build": "tsc && npm run copy-header && electron-builder --dir",
     "build-win": "tsc && npm run copy-header && electron-builder -w nsis",
     "build-win-ptb": "tsc && electron-builder -w portable",

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,0 +1,13 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld(
+    'soundcloudAPI', 
+    {
+        sendTrackUpdate: (data: any, reason: string) => {
+        ipcRenderer.send('soundcloud:track-update', {
+            data,
+            reason
+        });
+    }
+  }
+);

--- a/src/services/audioMonitorService.ts
+++ b/src/services/audioMonitorService.ts
@@ -1,0 +1,132 @@
+export const audioMonitorScript = `
+(function() {
+  // Avoid duplicate injections
+  if (window.__soundCloudMonitorActive) return;
+  window.__soundCloudMonitorActive = true;
+  
+  console.debug('monitor script injected');
+  
+  // Track current playback state
+  let isCurrentlyPlaying = false;
+  
+  function getTrackInfo() {
+    const playButton = document.querySelector('.playControls__play');
+    const isPlaying = playButton ? playButton.classList.contains('playing') : false;
+    
+    const authorEl = document.querySelector('.playbackSoundBadge__lightLink');
+    const artworkEl = document.querySelector('.playbackSoundBadge__avatar .image__lightOutline span');
+    const elapsedEl = document.querySelector('.playbackTimeline__timePassed span:last-child');
+    const durationEl = document.querySelector('.playbackTimeline__duration span:last-child');
+    const urlEl = document.querySelector('.playbackSoundBadge__titleLink');
+    
+    return {
+      title: artworkEl ? artworkEl.getAttribute('aria-label') : '',
+      author: authorEl ? authorEl.textContent.trim() : '',
+      artwork: artworkEl ? artworkEl.style.backgroundImage.replace(/^url\\(['"]?|['"]?\\)$/g, '') : '',
+      elapsed: elapsedEl ? elapsedEl.textContent.trim() : '',
+      duration: durationEl ? durationEl.textContent.trim() : '',
+      isPlaying: isPlaying,
+      url: urlEl ? urlEl.href.split('?')[0] : ''
+    };
+  }
+
+  function notifyPlaybackStateChange() {
+    const trackInfo = getTrackInfo();
+    const stateChanged = trackInfo.isPlaying !== isCurrentlyPlaying;
+    
+    if (stateChanged || !window.__initialStateSent) {
+      isCurrentlyPlaying = trackInfo.isPlaying;
+      window.__initialStateSent = true;
+      
+    window.soundcloudAPI.sendTrackUpdate(trackInfo, 'playback-state-change');
+    console.debug('Playback state change:', trackInfo.isPlaying ? 'playing' : 'paused', trackInfo);
+      
+    }
+  }
+  
+  // Monitor play button state changes directly
+  function setupPlaybackObserver() {
+    const playButton = document.querySelector('.playControls__play');
+    if (!playButton) return false;
+    
+    const observer = new MutationObserver(() => {
+      notifyPlaybackStateChange();
+    });
+    
+    observer.observe(playButton, { 
+      attributes: true,
+      attributeFilter: ['class'] // class changes indicate play/pause. can also do title and label
+    });
+    
+    return true;
+  }
+  
+  // Monitor playback controls for direct clicks
+  function monitorPlaybackControls() {
+    const playPauseButton = document.querySelector('.playControl');
+    if (playPauseButton && !playPauseButton.__monitored) {
+      playPauseButton.__monitored = true;
+      playPauseButton.addEventListener('click', () => {
+        console.debug('Play/pause button');
+        // Small delay to allow the class to update
+        setTimeout(notifyPlaybackStateChange, 50);
+      });
+    }
+    
+    // Monitor prev/next buttons too as they affect playback
+    const prevButton = document.querySelector('.skipControl__previous');
+    const nextButton = document.querySelector('.skipControl__next');
+    
+    if (prevButton && !prevButton.__monitored) {
+      prevButton.__monitored = true;
+      prevButton.addEventListener('click', () => {
+        console.debug('Previous track button clicked');
+        // Wait a bit longer for track to change
+        setTimeout(notifyPlaybackStateChange, 300);
+      });
+    }
+    
+    if (nextButton && !nextButton.__monitored) {
+      nextButton.__monitored = true;
+      nextButton.addEventListener('click', () => {
+        console.debug('Next track button clicked');
+        // Wait a bit longer for track to change
+        setTimeout(notifyPlaybackStateChange, 300);
+      });
+    }
+  }
+  
+  // Initial setup
+  function initialize() {
+    const playbackObserverSet = setupPlaybackObserver();
+    monitorPlaybackControls();
+    
+    window.__initialStateSent = false;
+    notifyPlaybackStateChange();
+    
+    // Watch for dynamically loaded elements
+    if (!playbackObserverSet) {
+      const documentObserver = new MutationObserver(() => {
+        if (!document.querySelector('.playControls__play')) return;
+        
+        if (setupPlaybackObserver()) {
+          monitorPlaybackControls();
+          documentObserver.disconnect();
+        }
+      });
+      
+      documentObserver.observe(document.body, {
+        childList: true,
+        subtree: true
+      });
+    }
+  }
+  
+  // Start monitoring
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    initialize();
+  } else {
+    document.addEventListener('DOMContentLoaded', initialize);
+  }
+})();
+`;

--- a/src/services/thumbarService.ts
+++ b/src/services/thumbarService.ts
@@ -16,27 +16,30 @@ export class ThumbarService {
         const playIcon = nativeImage.createFromPath(path.join(__dirname, '../../assets/icons/play.ico'));
         const pauseIcon = nativeImage.createFromPath(path.join(__dirname, '../../assets/icons/pause.ico'));
         const forwardIcon = nativeImage.createFromPath(path.join(__dirname, '../../assets/icons/forward.ico'));
-
-        win.setThumbarButtons([
-            {
+        const flags = ['nobackground']
+        const buttons = [
+             {
                 tooltip: this.translationService.translate('previous'),
                 icon: backwardIcon,
                 click: () => {
                     mainWindow.webContents.executeJavaScript(`
                         document.querySelector('.skipControl__previous')?.click();
                     `);
-                }
+                },
+                flags: flags
             },
             {
                 tooltip: isPlaying ? this.translationService.translate('pause') : this.translationService.translate('play'),
                 icon: isPlaying ? pauseIcon : playIcon,
                 click: () => {
                     isPlaying = !isPlaying;
-                    this.updateThumbarButtons(win, isPlaying, mainWindow);
                     mainWindow.webContents.executeJavaScript(`
                         document.querySelector('.playControl')?.click();
                     `);
-                }
+                    buttons[1].tooltip = isPlaying ? this.translationService.translate('pause') : this.translationService.translate('play')
+                },
+                flags: flags
+
             },
             {
                 tooltip: this.translationService.translate('next'),
@@ -45,8 +48,11 @@ export class ThumbarService {
                     mainWindow.webContents.executeJavaScript(`
                         document.querySelector('.skipControl__next')?.click();
                     `);
-                }
+                },
+                flags: flags
+
             }
-        ]);
+        ]
+        win.setThumbarButtons(buttons);
     }
 }


### PR DESCRIPTION
* Implement DOM listener for soundcloud events
* Add back thumbbar functionality
* Add `--dev` flag for debugging locally

I noticed the thumbbar widget implementation was written but unused. I'm guessing it was 
either due to the polling method used to determine if audio was playing, so the thumbbar wouldn't always reflect the true media state, or something with OS differences

I've only tested this on windows.