### PR TITLE
fix: last.fm initialization ignoring persisted toggle setting

### DIFF
--- a/src/services/lastFmService.ts
+++ b/src/services/lastFmService.ts
@@ -63,13 +63,6 @@ export class LastFmService {
     constructor(window: BrowserView, store: ElectronStore) {
         this.window = window;
         this.store = store;
-
-        // Initialize Last.fm state from store
-        const apikey = this.store.get('lastFmApiKey');
-        const secret = this.store.get('lastFmSecret');
-        if (apikey && secret) {
-            this.store.set('lastFmEnabled', true);
-        }
     }
 
     private async getLastFmSession(api_key: string, token: string) {


### PR DESCRIPTION
Not sure if it's intentional, but I noticed Last.fm is being turned on automatically upon each initialization, thus overriding the user's choice when they have the respective fields filled (lastFmApiKey, lastFmSecret).

---

Reproduction steps:

1. Enable Last.fm scrobbling with all fields filled out, apply changes
2. Restart app, see that it's turned off
3. Restart app again, see it's turned back on