### PR TITLE
fix: prevent webhooks and scrobbles from firing when paused

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1102,15 +1102,15 @@ function setupAudioHandler() {
 
         lastTrackInfo = result;
 
-        // Update services only if track is playing
-        if (result.isPlaying && result.title && result.author && result.duration) {
+        // Update services on track update
+        if (result.title && result.author && result.duration) {
             await Promise.all([
                 lastFmService.updateTrackInfo({
                     title: result.title,
                     author: result.author,
                     duration: result.duration,
                     elapsed: result.elapsed,
-                }),
+                }, result.isPlaying),
                 webhookService.updateTrackInfo({
                     title: result.title,
                     author: result.author,
@@ -1118,7 +1118,7 @@ function setupAudioHandler() {
                     url: result.url,
                     artwork: result.artwork,
                     elapsed: result.elapsed,
-                }),
+                }, result.isPlaying),
                 presenceService.updatePresence(result),
             ]);
         } else {


### PR DESCRIPTION
I noticed that both the Last.fm & Webhook services will continue to trigger (on playblack-state-change) if a track is paused. This PR resolves that issue.