### PR TITLE
Reduce macos memory usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "soundcloud-rpc",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "soundcloud-rpc",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "license": "MIT",
             "dependencies": {
                 "@ghostery/adblocker-electron": "^2.11.3",

--- a/src/notifications/notificationManager.ts
+++ b/src/notifications/notificationManager.ts
@@ -1,26 +1,47 @@
 import { BrowserView, BrowserWindow, ipcMain } from 'electron';
 import type { ThemeColors } from '../utils/colorExtractor';
 
+const isMac = process.platform === 'darwin';
+
 export class NotificationManager {
-    private view: BrowserView;
+    private view: BrowserView | null = null;
     private queue: string[] = [];
     private isDisplaying = false;
     private parentWindow: BrowserWindow;
     private themeColors: ThemeColors | null = null;
     private devMode = process.argv.includes('--dev');
+    private useMacOptimizations = process.platform === 'darwin';
 
     constructor(parentWindow: BrowserWindow) {
         this.parentWindow = parentWindow;
+    }
+
+    private ensureView(): BrowserView {
+        if (this.view) return this.view;
         this.view = new BrowserView({
             webPreferences: {
                 nodeIntegration: true,
                 contextIsolation: false,
                 sandbox: false,
-                spellcheck: false,
                 devTools: this.devMode,
-                affinity: 'ui',
+                ...(isMac ? { spellcheck: false } : {}),
             },
         });
+        return this.view;
+    }
+
+    private teardownView(): void {
+        if (!this.view) return;
+        const view = this.view;
+        try {
+            this.parentWindow.removeBrowserView(view);
+        } catch {}
+        if (this.useMacOptimizations) {
+            try {
+                (view.webContents as any).destroy();
+            } catch {}
+            this.view = null;
+        }
     }
 
     public setThemeColors(colors: ThemeColors | null): void {
@@ -37,7 +58,7 @@ export class NotificationManager {
     private displayNext(): void {
         if (this.queue.length === 0) {
             this.isDisplaying = false;
-            this.parentWindow.removeBrowserView(this.view);
+            this.teardownView();
             return;
         }
 
@@ -47,8 +68,9 @@ export class NotificationManager {
         const width = 400; // increased from 300
         const height = 70; // increased from 50
 
-        this.parentWindow.addBrowserView(this.view);
-        this.view.setBounds({
+        const view = this.ensureView();
+        this.parentWindow.addBrowserView(view);
+        view.setBounds({
             x: Math.floor((bounds.width - width) / 2),
             y: bounds.height - height - 100, // increased from 20 to move it up
             width,
@@ -119,6 +141,6 @@ export class NotificationManager {
             setTimeout(() => this.displayNext(), 100);
         });
 
-        this.view.webContents.loadURL(`data:text/html,${encodeURIComponent(html)}`);
+        view.webContents.loadURL(`data:text/html,${encodeURIComponent(html)}`);
     }
 }

--- a/src/notifications/notificationManager.ts
+++ b/src/notifications/notificationManager.ts
@@ -7,6 +7,7 @@ export class NotificationManager {
     private isDisplaying = false;
     private parentWindow: BrowserWindow;
     private themeColors: ThemeColors | null = null;
+    private devMode = process.argv.includes('--dev');
 
     constructor(parentWindow: BrowserWindow) {
         this.parentWindow = parentWindow;
@@ -14,7 +15,10 @@ export class NotificationManager {
             webPreferences: {
                 nodeIntegration: true,
                 contextIsolation: false,
-                transparent: true,
+                sandbox: false,
+                spellcheck: false,
+                devTools: this.devMode,
+                affinity: 'ui',
             },
         });
     }

--- a/src/settings/confirmPopup.ts
+++ b/src/settings/confirmPopup.ts
@@ -2,6 +2,7 @@ import { BrowserView, BrowserWindow, ipcMain } from 'electron';
 
 let confirmPopupView: BrowserView | null = null;
 const devMode = process.argv.includes('--dev');
+const isMac = process.platform === 'darwin';
 
 function escapeHtml(value: string): string {
     return value
@@ -35,9 +36,8 @@ export async function showHomepageConfirmDialog(mainWindow: BrowserWindow, url: 
             nodeIntegration: true,
             contextIsolation: false,
             sandbox: false,
-            spellcheck: false,
             devTools: devMode,
-            affinity: 'ui',
+            ...(isMac ? { spellcheck: false } : {}),
         },
     });
 

--- a/src/settings/confirmPopup.ts
+++ b/src/settings/confirmPopup.ts
@@ -1,6 +1,7 @@
 import { BrowserView, BrowserWindow, ipcMain } from 'electron';
 
 let confirmPopupView: BrowserView | null = null;
+const devMode = process.argv.includes('--dev');
 
 function escapeHtml(value: string): string {
     return value
@@ -34,6 +35,9 @@ export async function showHomepageConfirmDialog(mainWindow: BrowserWindow, url: 
             nodeIntegration: true,
             contextIsolation: false,
             sandbox: false,
+            spellcheck: false,
+            devTools: devMode,
+            affinity: 'ui',
         },
     });
 

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -3,32 +3,21 @@ import type ElectronStore = require('electron-store');
 import { TranslationService } from '../services/translationService';
 import type { ThemeColors } from '../utils/colorExtractor';
 
+const isMac = process.platform === 'darwin';
+
 export class SettingsManager {
-    private view: BrowserView;
+    private view: BrowserView | null = null;
     private isVisible = false;
     private parentWindow: BrowserWindow;
     private store: ElectronStore;
     private translationService: TranslationService;
     private devMode = process.argv.includes('--dev');
+    private useMacOptimizations = process.platform === 'darwin';
 
     constructor(parentWindow: BrowserWindow, store: ElectronStore, translationService: TranslationService) {
         this.parentWindow = parentWindow;
         this.store = store;
-        this.view = new BrowserView({
-            webPreferences: {
-                nodeIntegration: true,
-                contextIsolation: false,
-                sandbox: false,
-                spellcheck: false,
-                devTools: this.devMode,
-                affinity: 'ui',
-            },
-        });
         this.translationService = translationService;
-
-        // Add view immediately but keep it off-screen
-        this.parentWindow.addBrowserView(this.view);
-        this.view.setBounds({ x: 0, y: -10000, width: 0, height: 0 });
 
         // Add resize listener
         this.parentWindow.on('resize', () => {
@@ -36,17 +25,9 @@ export class SettingsManager {
                 this.updateBounds();
             }
         });
-
-        // Preload content
-        this.view.webContents.loadURL(`data:text/html,${encodeURIComponent(this.getHtml())}`);
-
-        // Listen for hide message from the panel
-        this.view.webContents.on('console-message', (_, __, message) => {
-            if (message === 'hidePanel') {
-                this.isVisible = false;
-                this.view.setBounds({ x: 0, y: -10000, width: 0, height: 0 });
-            }
-        });
+        if (!this.useMacOptimizations) {
+            this.createView();
+        }
     }
 
     public toggle(): void {
@@ -57,7 +38,54 @@ export class SettingsManager {
         }
     }
 
+    private createView(): BrowserView {
+        if (this.view) return this.view;
+
+        this.view = new BrowserView({
+            webPreferences: {
+                nodeIntegration: true,
+                contextIsolation: false,
+                sandbox: false,
+                devTools: this.devMode,
+                ...(isMac ? { spellcheck: false } : {}),
+            },
+        });
+
+        // Add view immediately but keep it off-screen until shown
+        this.parentWindow.addBrowserView(this.view);
+        this.view.setBounds({ x: 0, y: -10000, width: 0, height: 0 });
+
+        // Preload content
+        this.view.webContents.loadURL(`data:text/html,${encodeURIComponent(this.getHtml())}`);
+
+        // Listen for hide message from the panel
+        this.view.webContents.on('console-message', (_, __, message) => {
+            if (message === 'hidePanel') {
+                this.isVisible = false;
+                if (this.useMacOptimizations) {
+                    this.teardownView();
+                } else if (this.view) {
+                    this.view.setBounds({ x: 0, y: -10000, width: 0, height: 0 });
+                }
+            }
+        });
+
+        return this.view;
+    }
+
+    private teardownView(): void {
+        if (!this.view) return;
+        try {
+            this.parentWindow.removeBrowserView(this.view);
+        } catch {}
+        try {
+            (this.view.webContents as any).destroy();
+        } catch {}
+        this.view = null;
+    }
+
     private updateBounds(): void {
+        if (!this.view) return;
         const bounds = this.parentWindow.getBounds();
         const width = Math.min(500, Math.floor(bounds.width * 0.4)); // 40% of window width, max 500px
         const HEADER_HEIGHT = 32; // Height of the window controls
@@ -1787,18 +1815,31 @@ export class SettingsManager {
     }
 
     private show(): void {
+        const wasCreated = this.view === null;
+        const view = this.createView();
         this.isVisible = true;
         this.updateBounds();
-        this.view.webContents.executeJavaScript(`
-            // Force a reflow to ensure animation works
-            document.body.style.opacity;
-            document.body.classList.add('visible');
-        `);
-        // Trigger translation updates when panel is shown
-        this.getView().webContents.send('update-translations');
+        const applyShowState = () => {
+            view.webContents.executeJavaScript(`
+                // Force a reflow to ensure animation works
+                document.body.style.opacity;
+                document.body.classList.add('visible');
+            `);
+            // Trigger translation updates when panel is shown
+            view.webContents.send('update-translations');
+            const isDark = this.store.get('theme', 'dark') === 'dark';
+            view.webContents.send('theme-changed', isDark);
+        };
+
+        if (wasCreated) {
+            view.webContents.once('did-finish-load', applyShowState);
+        } else {
+            applyShowState();
+        }
     }
 
     private hide(): void {
+        if (!this.view) return;
         this.view.webContents.executeJavaScript(`
             document.body.classList.remove('visible');
             setTimeout(() => {
@@ -1808,6 +1849,7 @@ export class SettingsManager {
     }
 
     public setThemeColors(colors: ThemeColors | null): void {
+        if (!this.view) return;
         if (!colors) {
             // Reset to default theme colors
             this.view.webContents.executeJavaScript(`
@@ -1832,15 +1874,13 @@ export class SettingsManager {
             .catch(console.error);
     }
 
-    public getView(): BrowserView {
-        if (!this.view) {
-            throw new Error('Settings view is not initialized');
-        }
+    public getView(): BrowserView | null {
         return this.view;
     }
 
     public updateTranslations(translationService: TranslationService): void {
         this.translationService = translationService;
-        this.getView().webContents.send('update-translations');
+        if (!this.view) return;
+        this.view.webContents.send('update-translations');
     }
 }

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -9,6 +9,7 @@ export class SettingsManager {
     private parentWindow: BrowserWindow;
     private store: ElectronStore;
     private translationService: TranslationService;
+    private devMode = process.argv.includes('--dev');
 
     constructor(parentWindow: BrowserWindow, store: ElectronStore, translationService: TranslationService) {
         this.parentWindow = parentWindow;
@@ -17,6 +18,10 @@ export class SettingsManager {
             webPreferences: {
                 nodeIntegration: true,
                 contextIsolation: false,
+                sandbox: false,
+                spellcheck: false,
+                devTools: this.devMode,
+                affinity: 'ui',
             },
         });
         this.translationService = translationService;


### PR DESCRIPTION
What i changed (macos only)
- disable back/forward cache, limit renderer count to 1, low-end device mode, tiny disk/media cache
- settings + notifications views are created only when needed and destroyed when hidden
- disable spellcheck
- clear cache/history on memory pressure

- same look + behavior, less memory overhead
- fewer idle renderers
- on my mac it dropped from ~550mb to ~250mb while music is playing
- no changes for windows/linux

(Tested on a 2024 M3 Macbook Air)