### PR TITLE
Support for Discord Webhooks + Navigating with backspace

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -437,6 +437,29 @@ function setupWindowControls() {
     adjustContentViews();
 }
 
+function setupBackspaceNavigation() {
+    if (!contentView) return;
+
+    contentView.webContents.on('before-input-event', (event, input) => {
+        if (input.type === 'keyDown' && input.key === 'Backspace') {
+            // Check if we can go back in history
+            if (contentView.webContents.navigationHistory.canGoBack()) {
+                event.preventDefault();
+                contentView.webContents.navigationHistory.goBack();
+                
+                // Update header navigation buttons
+                if (headerView && headerView.webContents) {
+                    const state = {
+                        canGoBack: contentView.webContents.navigationHistory.canGoBack(),
+                        canGoForward: contentView.webContents.navigationHistory.canGoForward(),
+                    };
+                    headerView.webContents.send('navigation-state-changed', state);
+                }
+            }
+        }
+    });
+}
+
 let headerView: BrowserView | null;
 let contentView: BrowserView;
 
@@ -560,7 +583,7 @@ async function init() {
     });
 
     setupWindowControls();
-
+    setupBackspaceNavigation();
     initializeShortcuts();
 
     setupThemeHandlers();

--- a/src/services/webhookService.ts
+++ b/src/services/webhookService.ts
@@ -112,20 +112,55 @@ export class WebhookService {
             return;
         }
 
+        const isDiscord = webhookUrl.includes('discord.com/api/webhooks');
+        let payload: any;
+
+        if (isDiscord) {
+            const artistUrl = trackData.originUrl.substring(0, trackData.originUrl.lastIndexOf('/'));
+            payload = {
+                username: "SoundCloud RPC",
+                avatar_url: "https://raw.githubusercontent.com/richardhbtz/soundcloud-rpc/refs/heads/main/assets/icons/soundcloud.png",
+                embeds: trackData.trackArt ? [{
+                    title: `${trackData.track}`,
+                    url: trackData.originUrl,
+                    color: 0xFF5500,
+                    thumbnail: {
+                        url: trackData.trackArt
+                    },
+                    fields: [
+                        {
+                            name: "Artist",
+                            value: `[${trackData.artist}](${artistUrl})`,
+                            inline: true
+                        },
+                        {
+                            name: "Duration",
+                            value: `${Math.floor(trackData.duration / 60)}:${(trackData.duration % 60).toString().padStart(2, '0')}`,
+                            inline: true
+                        }
+                    ],
+                    timestamp: new Date().toISOString()
+                }] : []
+                };
+        }
+        else {
+            payload = {
+                timestamp: new Date().toISOString(),
+                ...trackData,
+            };
+        }
         try {
             const response = await fetch(webhookUrl, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({
-                    timestamp: new Date().toISOString(),
-                    ...trackData,
-                }),
+                body: JSON.stringify(payload),
             });
 
             if (!response.ok) {
-                console.error('Webhook failed:', response.status, response.statusText);
+                const errorText = await response.text();
+                console.error(`Webhook failed (${response.status}):`, errorText);
             } else {
                 console.log(`Webhook sent for ${trackData.artist} - ${trackData.track}`);
             }


### PR DESCRIPTION
Two updates:
1. Since the project itself promotes as an RPC for Discord, not supporting Discord Webhooks is not good. I added support for Discord Webhooks.
<img width="1445" height="446" alt="image" src="https://github.com/user-attachments/assets/171c8308-04c2-438b-b123-8886d90b269d" />


2. Navigating with backspace is possible now, however, we can only go back to the previous page not the other way.